### PR TITLE
Restore resolution at 600x600dpi

### DIFF
--- a/Canon-LBP-2900.ppd
+++ b/Canon-LBP-2900.ppd
@@ -47,7 +47,7 @@
 *OpenUI *Resolution/Resolution: PickOne
 *OrderDependency: 10 AnySetup *Resolution
 *DefaultResolution: 600dpi
-*Resolution 600dpi/600 DPI: "<</HWResolution[600 400]/cupsBitsPerColor 1/cupsRowCount 70/cupsRowFeed 592/cupsRowStep 0/cupsColorSpace 3>>setpagedevice"
+*Resolution 600dpi/600 DPI: "<</HWResolution[600 600]/cupsBitsPerColor 1/cupsRowCount 70/cupsRowFeed 592/cupsRowStep 0/cupsColorSpace 3>>setpagedevice"
 *CloseUI: *Resolution
 *DefaultFont: Courier
 *Font AvantGarde-Book: Standard "(1.05)" Standard ROM

--- a/src/prn_lbp2900.c
+++ b/src/prn_lbp2900.c
@@ -158,7 +158,7 @@ static bool lbp2900_page_prologue(struct printer_state_s *state, const struct pa
 
 	uint8_t pageparms[] = {
 		0x00, 0x00, 0x30, 0x2A, /* sz */ 0x02, 0x00, 0x00, 0x00,
-		0x1C, 0x1C, 0x1C, 0x1C, pt1, /* adapt */ 0x81, 0x04, 0x00,
+		0x1C, 0x1C, 0x1C, 0x1C, pt1, /* adapt */ 0x11, 0x04, 0x00,
 		0x01, 0x01, /* img ref */ 0x00, save, 0x00, 0x00,
 		/* height margin 118 */ 0x76, 0x00,
 		/*  width margin 78 */  0x4e, 0x00,
@@ -278,8 +278,8 @@ static void lbp2900_page_setup(struct printer_state_s *state,
 	(void) width;
 	dims->band_size = 70;
 	dims->line_size = 4736 / 8;
-	if (height > 4520)
-		dims->num_lines = 4520;
+	if (height > 6778)
+		dims->num_lines = 6778;
 	else
 		dims->num_lines = height;
 }


### PR DESCRIPTION
HI Alex,

finally I resolved to restore the resolution to 600x600dpi as default so that also images can be printed in a good quality,  until it will be possible to choice the more suitable resolution at printing time. In fact from my tests the resolution 600x400dpi is only suitable for text.

best regards
Laura

PS. This could close the issue #3.
