### PR TITLE
Add support for all media types

### DIFF
--- a/Canon-LBP2900.ppd
+++ b/Canon-LBP2900.ppd
@@ -3,7 +3,7 @@
 *%%%% Created by the CUPS PPD Compiler CUPS v2.2.10.
 *% (C)2020 Moses Chong
 *FormatVersion: "4.3"
-*FileVersion: "0.1.2"
+*FileVersion: "0.1.3"
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "CNLB2K9.ppd"
@@ -11,7 +11,7 @@
 *Manufacturer: "Canon Inc"
 *ModelName: "Canon Inc LBP2900/LBP3010 r2c"
 *ShortNickName: "Canon Inc LBP2900/LBP3010 r2c"
-*NickName: "Canon Inc LBP2900/LBP3010 r2c, 0.1.2"
+*NickName: "Canon Inc LBP2900/LBP3010 r2c, 0.1.3"
 *PSVersion: "(3010.000) 0"
 *LanguageLevel: "3"
 *ColorDevice: False
@@ -293,13 +293,6 @@
 *DefaultColorModel: Gray
 *ColorModel Gray/Grayscale: "<</cupsColorSpace 3/cupsColorOrder 0/cupsCompression 2>>setpagedevice"
 *CloseUI: *ColorModel
-*OpenUI *captMediaWeight/Media Type B (Experimental): PickOne
-*OrderDependency: 11 AnySetup *captMediaWeight
-*DefaultcaptMediaWeight: pt2-1
-*captMediaWeight pt2-0/0: "<</MediaWeight 0>>setpagedevice"
-*captMediaWeight pt2-1/Default: "<</MediaWeight 1>>setpagedevice"
-*captMediaWeight pt2-2/2: "<</MediaWeight 2>>setpagedevice"
-*CloseUI: *captMediaWeight
 *OpenUI *captTonerSave/Toner Save: Boolean
 *OrderDependency: 10 AnySetup *captTonerSave
 *DefaultcaptTonerSave: False
@@ -315,7 +308,11 @@
 *OrderDependency: 10 AnySetup *MediaType
 *DefaultMediaType: Plain
 *MediaType Plain/Plain Paper: "<</MediaType(Plain)/cupsMediaType 0>>setpagedevice"
-*MediaType Thick/Thick Paper: "<</MediaType(Thick)/cupsMediaType 1>>setpagedevice"
+*MediaType Heavy/Heavy Paper: "<</MediaType(Heavy)/cupsMediaType 1>>setpagedevice"
+*MediaType PlainL/Plain Paper L: "<</MediaType(PlainL)/cupsMediaType 2>>setpagedevice"
+*MediaType HeavyH/Heavy Paper H: "<</MediaType(HeavyH)/cupsMediaType 3>>setpagedevice"
+*MediaType Transparency/Transparency: "<</MediaType(Transparency)/cupsMediaType 4>>setpagedevice"
+*MediaType Envelope/Envelope: "<</MediaType(Envelope)/cupsMediaType 5>>setpagedevice"
 *CloseUI: *MediaType
 *DefaultFont: Courier
 *Font AvantGarde-Book: Standard "(1.05)" Standard ROM
@@ -353,4 +350,4 @@
 *Font Times-Roman: Standard "(1.05)" Standard ROM
 *Font ZapfChancery-MediumItalic: Standard "(1.05)" Standard ROM
 *Font ZapfDingbats: Special "(001.005)" Special ROM
-*% End of CNLB2K9.ppd, 21444 bytes.
+*% End of CNLB2K9.ppd, 21449 bytes.

--- a/Canon-LBP3000.ppd
+++ b/Canon-LBP3000.ppd
@@ -3,7 +3,7 @@
 *%%%% Created by the CUPS PPD Compiler CUPS v2.2.10.
 *% (C)2020 Moses Chong
 *FormatVersion: "4.3"
-*FileVersion: "0.1.2"
+*FileVersion: "0.1.3"
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "CNLB3K.ppd"
@@ -11,7 +11,7 @@
 *Manufacturer: "Canon Inc"
 *ModelName: "Canon Inc LBP3000 r2c"
 *ShortNickName: "Canon Inc LBP3000 r2c"
-*NickName: "Canon Inc LBP3000 r2c, 0.1.2"
+*NickName: "Canon Inc LBP3000 r2c, 0.1.3"
 *PSVersion: "(3010.000) 0"
 *LanguageLevel: "3"
 *ColorDevice: False
@@ -293,13 +293,6 @@
 *DefaultColorModel: Gray
 *ColorModel Gray/Grayscale: "<</cupsColorSpace 3/cupsColorOrder 0/cupsCompression 2>>setpagedevice"
 *CloseUI: *ColorModel
-*OpenUI *captMediaWeight/Media Type B (Experimental): PickOne
-*OrderDependency: 11 AnySetup *captMediaWeight
-*DefaultcaptMediaWeight: pt2-1
-*captMediaWeight pt2-0/0: "<</MediaWeight 0>>setpagedevice"
-*captMediaWeight pt2-1/Default: "<</MediaWeight 1>>setpagedevice"
-*captMediaWeight pt2-2/2: "<</MediaWeight 2>>setpagedevice"
-*CloseUI: *captMediaWeight
 *OpenUI *captTonerSave/Toner Save: Boolean
 *OrderDependency: 10 AnySetup *captTonerSave
 *DefaultcaptTonerSave: False
@@ -315,7 +308,11 @@
 *OrderDependency: 10 AnySetup *MediaType
 *DefaultMediaType: Plain
 *MediaType Plain/Plain Paper: "<</MediaType(Plain)/cupsMediaType 0>>setpagedevice"
-*MediaType Thick/Thick Paper: "<</MediaType(Thick)/cupsMediaType 1>>setpagedevice"
+*MediaType Heavy/Heavy Paper: "<</MediaType(Heavy)/cupsMediaType 1>>setpagedevice"
+*MediaType PlainL/Plain Paper L: "<</MediaType(PlainL)/cupsMediaType 2>>setpagedevice"
+*MediaType HeavyH/Heavy Paper H: "<</MediaType(HeavyH)/cupsMediaType 3>>setpagedevice"
+*MediaType Transparency/Transparency: "<</MediaType(Transparency)/cupsMediaType 4>>setpagedevice"
+*MediaType Envelope/Envelope: "<</MediaType(Envelope)/cupsMediaType 5>>setpagedevice"
 *CloseUI: *MediaType
 *DefaultFont: Courier
 *Font AvantGarde-Book: Standard "(1.05)" Standard ROM
@@ -353,4 +350,4 @@
 *Font Times-Roman: Standard "(1.05)" Standard ROM
 *Font ZapfChancery-MediumItalic: Standard "(1.05)" Standard ROM
 *Font ZapfDingbats: Special "(001.005)" Special ROM
-*% End of CNLB3K.ppd, 21404 bytes.
+*% End of CNLB3K.ppd, 21409 bytes.

--- a/src/canon-lbp.drv
+++ b/src/canon-lbp.drv
@@ -102,23 +102,6 @@ Version 0.1.3
 	MediaSize Statement
 	// End Less Common Sizes
 
-	// Paper Type B Options
-	/* 
-	   This option is wired directly to the pt2 register in the
-	   page prologue (see prn_lbp2900.c). Its exact purpose is not
-	   known, but it appears to be an adjustment to cater the printer
-	   for different paper weights.
-	   The proprietary drivers offers a 'Plain Paper L' and 'Heavy Paper H'
-	   option. The LBP 3000 manual describes Heavy Paper H as an option
-	   to 'get improved fixing properties' for thick paper and 
-	   Plain Paper L as an option reduce curling on plain paper.
-	   And then there's the Transparency option for clear plastic film...
-	 */
-	Option "captMediaWeight/Media Type B (Experimental)" PickOne AnySetup 11
-		Choice "pt2-0/0" "<</MediaWeight 0>>setpagedevice"
-		*Choice "pt2-1/Default" "<</MediaWeight 1>>setpagedevice"
-		Choice "pt2-2/2" "<</MediaWeight 2>>setpagedevice"
-
 	// Toner Save Option
 	Option "captTonerSave/Toner Save" Boolean AnySetup 10 
 		*Choice False/Disabled "<</cupsCompression 0>>setpagedevice"
@@ -127,7 +110,11 @@ Version 0.1.3
 	*Resolution k 1 70 592 0 "600dpi/600 DPI"
 	MaxSize 215.9mm 355.6mm		// US Legal
 	MediaType 0 "Plain/Plain Paper"
-	MediaType 1 "Thick/Thick Paper"
+	MediaType 1 "Heavy/Heavy Paper"
+	MediaType 2 "PlainL/Plain Paper L"
+	MediaType 3 "HeavyH/Heavy Paper H"
+	MediaType 4 "Transparency"
+	MediaType 5 "Envelope"
 	VariablePaperSize yes
 	{
 		// nearly matched to Alexey Galakhov's original 2011 specs

--- a/src/paper.c
+++ b/src/paper.c
@@ -22,11 +22,13 @@
 
 void page_set_dims(struct page_dims_s *dims, const struct cups_page_header2_s *header)
 {
-	dims->media_type_a = header->cupsMediaType;
-	dims->media_type_b = header->MediaWeight;
+	dims->media_type = header->cupsMediaType;
 	dims->paper_width  = header->PageSize[0] * header->HWResolution[0] / 72;
 	dims->paper_height = header->PageSize[1] * header->HWResolution[1] / 72;
-	//using cupsCompression to reduce ink darkness, like Zebra printers
+	/* 
+		The use of cupsCompression to toggle toner save was inspired by the
+	 	use of the same attribute to control darkness in label printer drivers.
+	*/
 	dims->toner_save = header->cupsCompression; 
 	dims->margin_height = header->Margins[0];
 	dims->margin_width = header->Margins[1];

--- a/src/paper.h
+++ b/src/paper.h
@@ -25,8 +25,7 @@ struct cups_page_header2_s;
 
 struct page_dims_s {
 	/* set by CUPS */
-	unsigned media_type_a;
-	unsigned media_type_b;
+	unsigned media_type;
 	unsigned paper_width;
 	unsigned paper_height;
 	unsigned toner_save;


### PR DESCRIPTION
Hi again, here's another edit that adds proper support for different paper types and transparencies. 

After poking around with Wireshark, I think byte 36 in the page prologue parameters has been figured out. From what I can see, byte 36 on the LBP3000 controls the heater on the fuser unit. It seems that the printer has a long heating modes for heavy paper (which adds a delay of around 6s or 15s per page), and an "extra soft" mode for transparencies and envelopes.

I still don't know exactly what byte 12 does to the printer, though.