### PR TITLE
Remove Makefile.in from package

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,5 +13,8 @@ rastertocapt_SOURCES = rastertocapt.c \
 
 rastertocapt_SOURCES += prn_lbp2900.c
 
-AM_CFLAGS = -std=c99 -Wall -Wextra -pedantic $(CUPS_CFLAGS)
 rastertocapt_LDADD = $(CUPS_LIBS)
+
+nodist_data_DATA = Makefile.in
+
+AM_CFLAGS = -std=c99 -Wall -Wextra -pedantic $(CUPS_CFLAGS)


### PR DESCRIPTION
Hi Alex,
this only remove Makefile.in from tarball when 'make dist' is used.