### PR TITLE
Enable preliminary LBP3100/3108/3150 support

### DIFF
--- a/src/prn_lbp2900.c
+++ b/src/prn_lbp2900.c
@@ -496,3 +496,4 @@ static struct lbp2900_ops_s lbp3010_ops = {
 	.wait_ready = capt_wait_xready_only,
 };
 register_printer("LBP3010/LBP3018/LBP3050", lbp3010_ops.ops, WORKS);
+register_printer("LBP3100/LBP3108/LBP3150", lbp3010_ops.ops, EXPERIMENTAL);


### PR DESCRIPTION
Just a little update related to issue #13. I suggested an edit to get an LBP3108 to work that was reported to have worked: https://github.com/agalakhov/captdriver/issues/13#issuecomment-854294534.