### PR TITLE
Revert df6e257

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 SUBDIRS = src tests
 
-dist_doc_DATA = SPECS INSTALL.md
+dist_doc_DATA = SPECS INSTALL.git
 EXTRA_DIST = src/canon-lbp.drv ppd
 nodist_data_DATA = Makefile.in
 


### PR DESCRIPTION
The Makefile.am change in df6e257 was a mistake, this PR reverts it to the previous version (which works).