### PR TITLE
Remove capt_cleanup()

### DIFF
--- a/src/capt-command.c
+++ b/src/capt-command.c
@@ -30,8 +30,6 @@
 
 static uint8_t capt_iobuf[0x10000];
 static size_t  capt_iosize;
-static cups_sc_status_t last_send_status = CUPS_SC_STATUS_NONE;
-static bool sendrecv_started = false;
 
 static void capt_debug_buf(const char *level, size_t size)
 {
@@ -205,28 +203,3 @@ void capt_multi_send(void)
 	capt_send_buf();
 }
 
-void capt_cleanup(void)
-{
-	/* For use with handling job cancellations */
-	if (sendrecv_started) {
-
-		if (last_send_status != CUPS_SC_STATUS_OK) {
-			capt_send_buf();
-			fprintf(stderr, "DEBUG: CAPT: finished interrupted send\n");
-		}
-
-		/* not else because recv cleanup is needed after finishing send */
-		if (last_send_status == CUPS_SC_STATUS_OK) {
-			size_t bytes = 0x10000;
-			size_t bs = 64;
-			while(bytes > 0) {
-				bytes -= bs;
-				cupsBackChannelRead(NULL, bs, 0.01);
-			}
-			fprintf(stderr, "DEBUG: CAPT: finished interrupted recv\n");
-		}
-
-	capt_iosize = 0;
-	sendrecv_started = false;
-	}
-}

--- a/src/prn_lbp2900.c
+++ b/src/prn_lbp2900.c
@@ -369,7 +369,6 @@ static void lbp2900_cancel_cleanup(struct printer_state_s *state)
 	const struct capt_status_s *status = lbp2900_get_status(state->ops);
 	uint8_t jbuf[2] = { LO(job), HI(job) };
 
-	capt_cleanup();
 	capt_sendrecv(CAPT_GPIO, lbp2900_gpio_init, ARRAY_SIZE(lbp2900_gpio_init), NULL, 0);
 	send_job_start(4, status->page_completed);
 	capt_sendrecv(CAPT_JOB_END, jbuf, 2, NULL, 0);
@@ -382,7 +381,6 @@ static void lbp3010_cancel_cleanup(struct printer_state_s *state)
 	const struct capt_status_s *status = lbp2900_get_status(state->ops);
 	uint8_t jbuf[2] = { LO(job), HI(job) };
 
-	capt_cleanup();
 	capt_sendrecv(CAPT_GPIO, lbp3010_gpio_init, ARRAY_SIZE(lbp3010_gpio_init), NULL, 0);
 	send_job_start(4, status->page_completed);
 	capt_sendrecv(CAPT_JOB_END, jbuf, 2, NULL, 0);


### PR DESCRIPTION
When @missla imported the cancellation handling code in 05e6cdd, several flag-setting statements were omitted in `capt-command.c`. This means `capt_cleanup()` was effectively bypassed. However, job cancellation reliability remained the same compared to my version as of 5cefa27.

Thus `capt_cleanup()` wasn't really needed, and I am removing it to make things easier to read.

When you "expand all" `capt-command.c` in the diff view and search for `last_send_status` and `sendrecv_started` you'll know what I mean...