### PR TITLE
Don't use fprintf() in do_cancel()

### DIFF
--- a/src/rastertocapt.c
+++ b/src/rastertocapt.c
@@ -208,7 +208,6 @@ static void send_page_data(struct printer_state_s *state, const struct cached_pa
 static void do_cancel(int s)
 {
 	(void) s;
-	fprintf(stderr, "DEBUG: CAPT: begin job cancellation cleanup\n");
 
 	if (ops)
 		ops->cancel_cleanup(state);
@@ -228,7 +227,6 @@ static void do_cancel(int s)
 	if (state)
 		free_state();
 
-	fprintf(stderr, "DEBUG: CAPT: job cancellation cleanup complete\n");
 	exit(1);
 }
 


### PR DESCRIPTION
I recently learned that it is not a good idea to use the `printf` family of functions in a signal handler, and `do_cancel()` is our SIGTERM handler.

Here's where I learned about this:
https://stackoverflow.com/questions/9547949/printf-is-not-working-in-c-signal-handler
https://stackoverflow.com/questions/3941271/why-are-malloc-and-printf-said-as-non-reentrant