### PR TITLE
Add manual duplex mode

### DIFF
--- a/src/canon-lbp.drv
+++ b/src/canon-lbp.drv
@@ -16,7 +16,7 @@ Copyright "(C)2020 Moses Chong"
 ColorModel "Gray/Grayscale" k chunky 2
 Filter application/vnd.cups-raster 1 rastertocapt
 *Manufacturer "Canon Inc"
-Version 0.1.3
+Version 0.1.4
 {
 	Font *
 
@@ -24,6 +24,10 @@ Version 0.1.3
 	Option "captTonerSave/Toner Save" Boolean AnySetup 10
         *Choice False/Disabled "<</cupsInteger0 0>>setpagedevice"
         Choice True/Enabled    "<</cupsInteger0 1>>setpagedevice"
+
+	Option "captManualDuplex/Manual Duplex" Boolean AnySetup 10
+	*Choice False/Disabled	"<</cupsInteger2 0>>setpagedevice"
+	Choice True/Enabled	"<</cupsInteger2 1>>setpagedevice"
 
 	{
                 *Resolution k 1 70 592 0 "600dpi/600 DPI"

--- a/src/paper.c
+++ b/src/paper.c
@@ -29,6 +29,7 @@ void page_set_dims(struct page_dims_s *dims, const struct cups_page_header2_s *h
 	dims->paper_height = header->cupsHeight; //header->PageSize[1] * header->HWResolution[1] / 72;
 	dims->toner_save = header->cupsInteger[0];
 	dims->ink_k = header->cupsInteger[1];
+	dims->manual_duplex = header->cupsInteger[2];
 	dims->line_size = header->PageSize[0];
 	dims->num_lines = header->cupsHeight;
 	dims->band_size = header->cupsRowCount;

--- a/src/paper.h
+++ b/src/paper.h
@@ -31,6 +31,7 @@ struct page_dims_s {
 	unsigned paper_width;
 	unsigned paper_height;
 	unsigned toner_save;
+	unsigned manual_duplex;
 	unsigned ink_k;
 	unsigned margin_height;
 	unsigned margin_width;

--- a/src/rastertocapt.c
+++ b/src/rastertocapt.c
@@ -280,6 +280,10 @@ static void do_print(int fd)
 
 		fprintf(stderr, "DEBUG: CAPT: rastertocapt: start page %u\n", state->ipage);
 		if (ops->page_prologue) {
+			if (cached_page->dims.manual_duplex && state->ipage > 1) {
+				fprintf(stderr, "DEBUG: CAPT: rastertocapt: manual duplex: press button to continue\n");
+				ops->wait_user(state);
+			}
 			bool ok = ops->page_prologue(state, &cached_page->dims);
 			if (! ok) {
 				fprintf(stderr, "DEBUG: CAPT: rastertocapt: can't start page\n");


### PR DESCRIPTION
Printer will wait on user to feed the last printed sheet back into the input tray to print on the other side; press the button to continue. The printer will wait before every page from the second page onwards.

This feature could be useful for printers without a duplexer, or if the duplexer becomes damaged or worn out.