### PR TITLE
Enable Preliminary LBP6000/6018 Support

### DIFF
--- a/src/capt-command.h
+++ b/src/capt-command.h
@@ -49,6 +49,7 @@ enum capt_command {
 	CAPT_UPLOAD_2   = 0xE0A5,
 	CAPT_FIRE       = 0xE0A7,
 	CAPT_JOB_END    = 0xE0A9,
+	CAPT_LBP6000_SETUP_0 = 0xE0BA,
 
 	CAPT_JOB_SETUP  = 0xE1A1,
 	CAPT_GPIO       = 0xE1A2,

--- a/src/prn_lbp2900.c
+++ b/src/prn_lbp2900.c
@@ -495,3 +495,4 @@ static struct lbp2900_ops_s lbp3010_ops = {
 };
 register_printer("LBP3010/LBP3018/LBP3050", lbp3010_ops.ops, WORKS);
 register_printer("LBP3100/LBP3108/LBP3150", lbp3010_ops.ops, EXPERIMENTAL);
+register_printer("LBP6000/LBP6018", lbp3010_ops.ops, EXPERIMENTAL);


### PR DESCRIPTION
Just an updated #54, with a cleaned up capt-command.h and squashed command list.